### PR TITLE
Added generation files for portaudio files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 *.gem
 *.rbc
+*.bundle
+*.o
+*_wrap.c
+/ext/Makefile
 /.config
 /coverage/
 /InstalledFiles

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Aurora is the enterprise end-to-end speech solution. This Ruby SDK will allow yo
 
 The SDK is currently in a pre-alpha release phase. Bugs and limited functionality should be expected.
 
+## Prerequisites
+- Ruby (2.5.0+)
+- Swig
+- PortAudio
+
 ## Installation
 **The Recommended Ruby version is 2.5.0+**
 
@@ -19,6 +24,13 @@ Or, if you prefer to build and install manually:
 $ gem build aurora-sdk.gemspec
 $ sudo gem install aurora-sdk-x.x.x.gem
 ```
+
+To build and install PortAudio bindings for Ruby:
+```
+$ rake build_pa
+```
+
+Simple running `rake install` will build and install the bindings, as well.
 
 ## Testing
 The full test suite can be run using `rake`. To specify an individual test file, use the `TEST` option for rake:

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,0 +1,3 @@
+require 'mkmf'
+$LIBS += ' -lportaudio'
+create_makefile('portaudio')

--- a/ext/portaudio.i
+++ b/ext/portaudio.i
@@ -1,6 +1,7 @@
-%module PortAudio
+%module portaudio
 %{
   #include <portaudio.h>
 %}
 
+%rename("%(strip:[Pa_])s") "";
 %include "/usr/local/include/portaudio.h"

--- a/ext/portaudio.i
+++ b/ext/portaudio.i
@@ -1,0 +1,6 @@
+%module PortAudio
+%{
+  #include <portaudio.h>
+%}
+
+%include "/usr/local/include/portaudio.h"


### PR DESCRIPTION
Included Rakefile updates and README/.gitignore, as well. Utilizes [SWIG](http://www.swig.org/), which automates wrapper generation for high-level programming languages, including Ruby. Will require you to have PortAudio and SWIG installed to run -- may try to automate this process later on. 